### PR TITLE
Prevent default built-in scripts from breaking minification groups. #9 #22

### DIFF
--- a/dependency-minification.php
+++ b/dependency-minification.php
@@ -728,6 +728,9 @@ class Dependency_Minification {
 			unset($extra['suffix']);
 			unset($extra['rtl']);
 			unset($extra['data']);
+			// Default scripts are not assigned 'group', so we use the original 'deps->args' value
+			if ( is_a( $wp_deps, 'WP_Scripts' ) && empty($extra['group']) && is_int($dep->args) )
+				$extra['group'] = $dep->args;
 			ksort($extra);
 			$key = serialize($extra);
 			$bundles[$key][] = $handle;

--- a/dependency-minification.php
+++ b/dependency-minification.php
@@ -729,8 +729,9 @@ class Dependency_Minification {
 			unset($extra['rtl']);
 			unset($extra['data']);
 			// Default scripts are not assigned 'group', so we use the original 'deps->args' value
-			if ( is_a( $wp_deps, 'WP_Scripts' ) && empty($extra['group']) && is_int($dep->args) )
+			if ( is_a( $wp_deps, 'WP_Scripts' ) && empty( $extra['group'] ) && is_int( $dep->args ) ) {
 				$extra['group'] = $dep->args;
+			}
 			ksort($extra);
 			$key = serialize($extra);
 			$bundles[$key][] = $handle;


### PR DESCRIPTION
It seems like WP default scripts don't get assigned a `group` value after all, the final argument of the call to register the admin-bar.js script is never used to assign the `group` data value, same goes for all other default scripts:

https://github.com/WordPress/WordPress/blob/master/wp-includes/script-loader.php#L327 :
https://github.com/WordPress/WordPress/blob/master/wp-includes/class.wp-dependencies.php#L127

unlike what wp_enqueue_script does:
`if ( $in_footer )  $wp_scripts->add_data( $_handle[0], 'group', 1 );`
https://github.com/WordPress/WordPress/blob/master/wp-includes/functions.wp-scripts.php#L157

So the solution here is to detect the `dep->args` value if no `extra['group']` is available, cause they're basically the same thing.
