### PR TITLE
Issue 48 Minify regex rewrite rule broken by external plugin / theme

### DIFF
--- a/dependency-minification.php
+++ b/dependency-minification.php
@@ -99,7 +99,7 @@ class Dependency_Minification {
 		}
 		$new_rules[$regex] = $redirect;
 
-		return $rules + $new_rules;
+		return array_merge( $rules, $new_rules );
 	}
 
 	static function remove_rewrite_rule() {

--- a/dependency-minification.php
+++ b/dependency-minification.php
@@ -5,7 +5,7 @@
  * Version: 0.9.7
  * Author: X-Team
  * Author URI: http://x-team.com/wordpress/
- * Text Domain: depmin
+ * Text Domain: dependency-minification
  * License: GPLv2+
  * Domain Path: /languages
  */
@@ -58,7 +58,7 @@ class Dependency_Minification {
 				'allow_not_modified_responses'        => true, // only needs to be true if not Akamaized and max-age is short
 				'admin_page_capability'               => 'edit_theme_options',
 				'show_error_messages'                 => ( defined( 'WP_DEBUG' ) && WP_DEBUG ),
-				'disable_if_wp_debug'                 => false, //true,
+				'disable_if_wp_debug'                 => true,
 			),
 			self::$options
 		) );
@@ -169,8 +169,8 @@ class Dependency_Minification {
 	static function admin_menu() {
 		self::$admin_page_hook = add_submenu_page(
 			self::ADMIN_PARENT_PAGE,
-			__( 'Dependency Minification', 'depmin' ),
-			__( 'Dep. Minification', 'depmin' ),
+			__( 'Dependency Minification', 'dependency-minification' ),
+			__( 'Dep. Minification', 'dependency-minification' ),
 			self::$options['admin_page_capability'],
 			self::ADMIN_PAGE_SLUG,
 			array( __CLASS__, 'admin_page' )
@@ -188,13 +188,13 @@ class Dependency_Minification {
 				<p><?php
 				echo sprintf(
 					'<strong>%1$s</strong>: %2$s',
-					__( 'Dependency Minification', 'depmin' ),
+					__( 'Dependency Minification', 'dependency-minification' ),
 					sprintf(
-						__( 'Pretty permalinks are not enabled in your %1$s, which is required for this plugin to operate. Select something other than Default (e.g. ?p=123)', 'depmin' ),
+						__( 'Pretty permalinks are not enabled in your %1$s, which is required for this plugin to operate. Select something other than Default (e.g. ?p=123)', 'dependency-minification' ),
 						sprintf(
 							'<a href="%1$s">%2$s</a>',
 							admin_url( 'options-permalink.php' ),
-							__( 'Permalinks Settings', 'depmin' )
+							__( 'Permalinks Settings', 'dependency-minification' )
 						)
 					)
 				);
@@ -220,19 +220,19 @@ class Dependency_Minification {
 			<?php if ( 'expire' === $updated_task ) : ?>
 				<p><?php
 				echo esc_html( sprintf(
-					_n( 'Expired %d minified dependency.', 'Expired %d minified dependencies.', $updated_count, 'depmin' ),
+					_n( 'Expired %d minified dependency.', 'Expired %d minified dependencies.', $updated_count, 'dependency-minification' ),
 					$updated_count
 				));
 				?></p>
 			<?php elseif ( 'purge' === $updated_task ) : ?>
 				<p><?php
 				echo esc_html( sprintf(
-					_n( 'Purged %d minified dependency.', 'Purged %d minified dependencies.', $updated_count, 'depmin' ),
+					_n( 'Purged %d minified dependency.', 'Purged %d minified dependencies.', $updated_count, 'dependency-minification' ),
 					$updated_count
 				) );
 				?></p>
 			<?php else: ?>
-				<p><?php esc_html_e( 'Updated.', 'depmin' ) ?></p>
+				<p><?php esc_html_e( 'Updated.', 'dependency-minification' ) ?></p>
 			<?php endif; ?>
 		</div>
 		<?php
@@ -243,10 +243,10 @@ class Dependency_Minification {
 	 */
 	static function admin_ajax_handler() {
 		if ( ! current_user_can( self::$options['admin_page_capability'] ) ) {
-			wp_die( __( 'You are not allowed to do that.', 'depmin' ) );
+			wp_die( __( 'You are not allowed to do that.', 'dependency-minification' ) );
 		}
 		if ( ! wp_verify_nonce( $_REQUEST['_wpnonce'], self::AJAX_ACTION ) ) {
-			wp_die( __( 'Nonce check failed. Try reloading the previous page.', 'depmin' ) );
+			wp_die( __( 'Nonce check failed. Try reloading the previous page.', 'dependency-minification' ) );
 		}
 		$updated_count = 0;
 		if ( ! empty( $_REQUEST['depmin_option_name'] ) && ! empty( $_REQUEST['depmin_task'] ) ) {
@@ -275,7 +275,7 @@ class Dependency_Minification {
 	static function admin_plugin_action_links( $links, $file ) {
 		if ( plugin_basename( __FILE__ ) === $file ) {
 			$admin_page_url  = admin_url( sprintf( '%s?page=%s', self::ADMIN_PARENT_PAGE, self::ADMIN_PAGE_SLUG ) );
-			$admin_page_link = sprintf( '<a href="%s">%s</a>', esc_url( $admin_page_url ), esc_html__( 'Settings', 'depmin' ) );
+			$admin_page_link = sprintf( '<a href="%s">%s</a>', esc_url( $admin_page_url ), esc_html__( 'Settings', 'dependency-minification' ) );
 			array_push( $links, $admin_page_link );
 		}
 		return $links;
@@ -283,13 +283,13 @@ class Dependency_Minification {
 
 	static function admin_page() {
 		if ( ! current_user_can( self::$options['admin_page_capability'] ) ) {
-			wp_die( __( 'You cannot access this page.', 'depmin' ) );
+			wp_die( __( 'You cannot access this page.', 'dependency-minification' ) );
 		}
 		$nonce = wp_create_nonce( self::AJAX_ACTION );
 		?>
 		<div class="wrap">
 			<div class="icon32" id="icon-tools"><br></div>
-			<h2><?php esc_html_e( 'Dependency Minification', 'depmin' ) ?></h2>
+			<h2><?php esc_html_e( 'Dependency Minification', 'dependency-minification' ) ?></h2>
 
 			<?php  ?>
 			<form action="<?php echo esc_url( admin_url( 'admin-ajax.php' ) ) ?>" method="post">
@@ -328,21 +328,21 @@ class Dependency_Minification {
 
 				<?php if ( self::$options['disable_if_wp_debug'] && ( defined( 'WP_DEBUG' ) && WP_DEBUG ) ): ?>
 					<div class="error">
-						<p><?php esc_html_e( 'Dependency Minification is disabled. Any minified dependencies below are cached. To minify new dependencies, disable WP_DEBUG or filter disable_if_wp_debug to be false.', 'depmin' ); ?></p>
+						<p><?php esc_html_e( 'Dependency Minification is disabled. Any minified dependencies below are cached. To minify new dependencies, disable WP_DEBUG or filter disable_if_wp_debug to be false.', 'dependency-minification' ); ?></p>
 					</div>
 				<?php endif; ?>
 
 				<?php if ( empty( $minified_dependencies ) ) : ?>
 					<p>
-						<em><?php esc_html_e( 'There are no minified dependencies yet. Try browsing the site.', 'depmin' ); ?></em>
+						<em><?php esc_html_e( 'There are no minified dependencies yet. Try browsing the site.', 'dependency-minification' ); ?></em>
 					</p>
 				<?php else : ?>
 					<div class="tablenav top">
 						<div class="alignleft actions">
 							<select name="depmin_task">
 								<option value="-1" selected="selected"><?php esc_html_e( 'Bulk Actions' ) ?></option>
-								<option value="expire"><?php esc_html_e( 'Expire', 'depmin' ) ?></option>
-								<option value="purge"><?php esc_html_e( 'Purge', 'depmin' ) ?></option>
+								<option value="expire"><?php esc_html_e( 'Expire', 'dependency-minification' ) ?></option>
+								<option value="purge"><?php esc_html_e( 'Purge', 'dependency-minification' ) ?></option>
 							</select>
 							<input type="submit" name="" id="doaction" class="button action" value="<?php esc_attr_e( 'Apply' ) ?>">
 						</div>
@@ -356,12 +356,12 @@ class Dependency_Minification {
 									<th scope="col" class="manage-column column-cb check-column">
 										<label class="screen-reader-text" for="cb-select-all-1"><?php esc_html_e( 'Select All' ) ?></label><input id="cb-select-all-<?php echo esc_attr( $i + 1 ); ?>" type="checkbox">
 									</th>
-									<th scope="col" class="manage-column column-dependencies"><?php esc_html_e( 'Dependencies', 'depmin' ) ?></th>
-									<th scope="col" class="manage-column column-count"><?php esc_html_e( 'Count', 'depmin' ) ?></th>
-									<th scope="col" class="manage-column column-compression"><?php esc_html_e( 'Compression', 'depmin' ) ?></th>
-									<th scope="col" class="manage-column column-type"><?php esc_html_e( 'Type', 'depmin' ) ?></th>
-									<th scope="col" class="manage-column column-last-modified"><?php esc_html_e( 'Last Modified', 'depmin' ) ?></th>
-									<th scope="col" class="manage-column column-expires"><?php esc_html_e( 'Expires', 'depmin' ) ?></th>
+									<th scope="col" class="manage-column column-dependencies"><?php esc_html_e( 'Dependencies', 'dependency-minification' ) ?></th>
+									<th scope="col" class="manage-column column-count"><?php esc_html_e( 'Count', 'dependency-minification' ) ?></th>
+									<th scope="col" class="manage-column column-compression"><?php esc_html_e( 'Compression', 'dependency-minification' ) ?></th>
+									<th scope="col" class="manage-column column-type"><?php esc_html_e( 'Type', 'dependency-minification' ) ?></th>
+									<th scope="col" class="manage-column column-last-modified"><?php esc_html_e( 'Last Modified', 'dependency-minification' ) ?></th>
+									<th scope="col" class="manage-column column-expires"><?php esc_html_e( 'Expires', 'dependency-minification' ) ?></th>
 								</tr>
 							</<?php echo $tcontainer;  // xss ok ?>>
 						<?php endforeach; ?>
@@ -380,13 +380,13 @@ class Dependency_Minification {
 								?>
 								<tr id="<?php echo esc_attr($option_name) ?>" valign="top">
 									<th scope="row" class="check-column">
-										<label class="screen-reader-text" for="cb-select-<?php echo esc_attr($option_name) ?>"><?php esc_html_e( 'Select minified dependency', 'depmin' ) ?></label>
+										<label class="screen-reader-text" for="cb-select-<?php echo esc_attr($option_name) ?>"><?php esc_html_e( 'Select minified dependency', 'dependency-minification' ) ?></label>
 										<input id="cb-select-<?php echo esc_attr($option_name) ?>" type="checkbox" name="depmin_option_name[]" value="<?php echo esc_attr($option_name) ?>" <?php disabled( $pending ) ?>>
 									</th>
 									<td class="column-dependencies">
 										<strong>
 											<?php for ( $i = 0; $i < count( $deps ); $i += 1 ) : ?>
-												<a href="<?php echo esc_url( $deps[$i]['src'] ) ?>" target="_blank" title="<?php esc_attr_e( 'View unminified source (opens in new window)', 'depmin' ) ?>"><?php echo esc_html( $deps[$i]['handle'] ) ?></a><?php if ( $i + 1 < count( $handles ) ) { esc_html_e( ', ' ); } ?>
+												<a href="<?php echo esc_url( $deps[$i]['src'] ) ?>" target="_blank" title="<?php esc_attr_e( 'View unminified source (opens in new window)', 'dependency-minification' ) ?>"><?php echo esc_html( $deps[$i]['handle'] ) ?></a><?php if ( $i + 1 < count( $handles ) ) { esc_html_e( ', ' ); } ?>
 											<?php endfor; ?>
 										</strong>
 										<?php if ( ! empty( $error ) ) : ?>
@@ -399,7 +399,7 @@ class Dependency_Minification {
 														$_link_params['depmin_task'] = 'purge';
 														?>
 														<a class="submitdelete" title="<?php esc_attr_e( 'Delete the cached error to try again.', 'depmin' ) ?>" href="<?php echo esc_url( add_query_arg( $_link_params, admin_url( 'admin-ajax.php' ) ) ) ?>">
-															<?php esc_html_e( 'Try again', 'depmin' ) ?>
+															<?php esc_html_e( 'Try again', 'dependency-minification' ) ?>
 														</a>
 													</span>
 												</p>
@@ -413,17 +413,17 @@ class Dependency_Minification {
 														$_link_params = $link_params;
 														$_link_params['depmin_task'] = 'expire';
 														?>
-														<a href="<?php echo esc_url( add_query_arg( $_link_params, admin_url( 'admin-ajax.php' ) ) ) ?>" title="<?php esc_attr_e( 'Expire this item to gracefully regenerate', 'depmin' ) ?>"><?php esc_html_e( 'Expire', 'depmin' ) ?></a> |
+														<a href="<?php echo esc_url( add_query_arg( $_link_params, admin_url( 'admin-ajax.php' ) ) ) ?>" title="<?php esc_attr_e( 'Expire this item to gracefully regenerate', 'dependency-minification' ) ?>"><?php esc_html_e( 'Expire', 'dependency-minification' ) ?></a> |
 													</span>
 													<span class="trash">
 														<?php
 														$_link_params = $link_params;
 														$_link_params['depmin_task'] = 'purge';
 														?>
-														<a class="submitdelete" title="<?php esc_attr_e( 'Purge item from cache (delete immediately; NOT recommended)', 'depmin' ) ?>" href="<?php echo esc_url( add_query_arg( $_link_params, admin_url( 'admin-ajax.php' ) ) ) ?>"><?php esc_html_e( 'Purge', 'depmin' ) ?></a> |
+														<a class="submitdelete" title="<?php esc_attr_e( 'Purge item from cache (delete immediately; NOT recommended)', 'dependency-minification' ) ?>" href="<?php echo esc_url( add_query_arg( $_link_params, admin_url( 'admin-ajax.php' ) ) ) ?>"><?php esc_html_e( 'Purge', 'dependency-minification' ) ?></a> |
 													</span>
 													<span class="view">
-														<a href="<?php echo esc_url( $minified_src ) ?>" target="_blank" title="<?php esc_attr_e( 'View minified dependencies (opens in new window)', 'depmin' ) ?>" rel="permalink"><?php esc_html_e( 'View minified', 'depmin' ) ?></a>
+														<a href="<?php echo esc_url( $minified_src ) ?>" target="_blank" title="<?php esc_attr_e( 'View minified dependencies (opens in new window)', 'dependency-minification' ) ?>" rel="permalink"><?php esc_html_e( 'View minified', 'dependency-minification' ) ?></a>
 													</span>
 												<?php else: ?>
 													<span class="trash">
@@ -431,7 +431,7 @@ class Dependency_Minification {
 														$_link_params = $link_params;
 														$_link_params['depmin_task'] = 'purge';
 														?>
-														<a class="submitdelete" title="<?php esc_attr_e( 'Delete the cached error to try again.', 'depmin' ) ?>" href="<?php echo esc_url( add_query_arg( $_link_params, admin_url( 'admin-ajax.php' ) ) ) ?>"><?php esc_html_e( 'Try again', 'depmin' ) ?></a>
+														<a class="submitdelete" title="<?php esc_attr_e( 'Delete the cached error to try again.', 'dependency-minification' ) ?>" href="<?php echo esc_url( add_query_arg( $_link_params, admin_url( 'admin-ajax.php' ) ) ) ?>"><?php esc_html_e( 'Try again', 'dependency-minification' ) ?></a>
 													</span>
 												<?php endif; ?>
 											</div>
@@ -440,13 +440,13 @@ class Dependency_Minification {
 									<td class="count column-count"><?php echo esc_html( count( $handles ) ) ?></td>
 									<td class="count column-compression"><?php
 										if ( empty( $unminified_size ) ) {
-											esc_html_e( 'N/A', 'depmin' );
+											esc_html_e( 'N/A', 'dependency-minification' );
 										} else {
 											$min = strlen( $contents );
 											$max = $unminified_size;
 											$percentage = round( 100 - ( $min / $max ) * 100 );
-											printf( '<meter min=0 max=100 value="%d" title="%s">', $percentage, esc_attr( sprintf( __( '(%1$d / %2$d)', 'depmin' ), $min, $max ) ) );
-											print esc_html( sprintf( __( '%1$d%%', 'depmin' ), $percentage ) );
+											printf( '<meter min=0 max=100 value="%d" title="%s">', $percentage, esc_attr( sprintf( __( '(%1$d / %2$d)', 'dependency-minification' ), $min, $max ) ) );
+											print esc_html( sprintf( __( '%1$d%%', 'dependency-minification' ), $percentage ) );
 											print '</meter>';
 										}
 
@@ -461,7 +461,7 @@ class Dependency_Minification {
 									<?php foreach ( $date_cols as $col => $time ) : ?>
 										<td class="<?php echo esc_attr( $col ) ?> column-<?php echo esc_attr( $col ) ?>">
 											<?php if ( $pending ) : ?>
-												<em><?php esc_html_e( '(Pending)', 'depmin' ) ?></em>
+												<em><?php esc_html_e( '(Pending)', 'dependency-minification' ) ?></em>
 											<?php else: ?>
 												<time title="<?php echo esc_attr( gmdate( 'c', $time ) ) ?>" datetime="<?php echo esc_attr( gmdate( 'c', $time ) ) ?>">
 													<?php if ( $time < time() ) : ?>

--- a/dependency-minification.php
+++ b/dependency-minification.php
@@ -88,7 +88,7 @@ class Dependency_Minification {
 	}
 
 	static function get_rewrite_regex() {
-		return sprintf( '^%s/%s', self::$options['endpoint'], self::FILENAME_PATTERN );
+		return sprintf( '^(?:.*/)?%s/%s', self::$options['endpoint'], self::FILENAME_PATTERN );
 	}
 
 	static function add_rewrite_rule( $rules ) {

--- a/dependency-minification.php
+++ b/dependency-minification.php
@@ -813,7 +813,7 @@ class Dependency_Minification {
 		try {
 			$is_css = ( 'styles' === $type );
 			if ( 'scripts' === $type ) {
-				require_once( dirname(__FILE__) . '/minify/JS/JSMin.php' );
+				require_once( dirname(__FILE__) . '/minify/JS/JSMinPlus.php' );
 			} elseif ( 'styles' === $type ) {
 				require_once( dirname(__FILE__) . '/minify/CSS/UriRewriter.php' );
 				require_once( dirname(__FILE__) . '/minify/CSS/Compressor.php' );
@@ -883,7 +883,7 @@ class Dependency_Minification {
 			// is the comment-reply.js in WordPress.
 			if ( 'scripts' === $type ) {
 				$minified_contents = join( "\n;;\n", $contents_for_each_dep );
-				$minified_contents = JSMin::minify($minified_contents);
+				$minified_contents = JSMinPlus::minify($minified_contents);
 				if ( false === $minified_contents ) {
 					throw new Dependency_Minification_Exception( 'JavaScript parse error' );
 				}

--- a/dependency-minification.php
+++ b/dependency-minification.php
@@ -5,7 +5,7 @@
  * Version: 0.9.7
  * Author: X-Team
  * Author URI: http://x-team.com/wordpress/
- * Text Domain: dependency-minification
+ * Text Domain: depmin
  * License: GPLv2+
  * Domain Path: /languages
  */
@@ -58,7 +58,7 @@ class Dependency_Minification {
 				'allow_not_modified_responses'        => true, // only needs to be true if not Akamaized and max-age is short
 				'admin_page_capability'               => 'edit_theme_options',
 				'show_error_messages'                 => ( defined( 'WP_DEBUG' ) && WP_DEBUG ),
-				'disable_if_wp_debug'                 => true,
+				'disable_if_wp_debug'                 => false, //true,
 			),
 			self::$options
 		) );
@@ -84,26 +84,26 @@ class Dependency_Minification {
 	static function hook_rewrites() {
 		add_filter( 'query_vars', array( __CLASS__, 'filter_query_vars' ) );
 		add_action( 'pre_get_posts', array( __CLASS__, 'handle_request' ) );
-		self::add_rewrite_rule();
+		add_filter( 'rewrite_rules_array', array( __CLASS__, 'add_rewrite_rule' ), 99999 );
 	}
 
 	static function get_rewrite_regex() {
 		return sprintf( '^%s/%s', self::$options['endpoint'], self::FILENAME_PATTERN );
 	}
 
-	static function add_rewrite_rule() {
+	static function add_rewrite_rule( $rules ) {
 		$regex    = self::get_rewrite_regex();
 		$redirect = 'index.php?';
 		for ( $i = 0; $i < count( self::$query_vars ); $i += 1 ) {
 			$redirect .= sprintf( '%s=$matches[%d]&', self::$query_vars[$i], $i + 1 );
 		}
-		add_rewrite_rule( $regex, $redirect, 'top' );
+		$new_rules[$regex] = $redirect;
+
+		return $rules + $new_rules;
 	}
 
 	static function remove_rewrite_rule() {
-		$regex = self::get_rewrite_regex();
-		global $wp_rewrite;
-		unset( $wp_rewrite->extra_rules_top[ $regex ] );
+		remove_filter( 'rewrite_rules_array', array( __CLASS__, 'add_rewrite_rule' ), 99999 );
 	}
 
 	protected static $is_footer = array(
@@ -116,7 +116,7 @@ class Dependency_Minification {
 	 */
 	static function activate() {
 		self::setup();
-		self::add_rewrite_rule();
+		add_filter( 'rewrite_rules_array', array( __CLASS__, 'add_rewrite_rule' ), 99999 );
 		flush_rewrite_rules();
 	}
 
@@ -169,8 +169,8 @@ class Dependency_Minification {
 	static function admin_menu() {
 		self::$admin_page_hook = add_submenu_page(
 			self::ADMIN_PARENT_PAGE,
-			__( 'Dependency Minification', 'dependency-minification' ),
-			__( 'Dep. Minification', 'dependency-minification' ),
+			__( 'Dependency Minification', 'depmin' ),
+			__( 'Dep. Minification', 'depmin' ),
 			self::$options['admin_page_capability'],
 			self::ADMIN_PAGE_SLUG,
 			array( __CLASS__, 'admin_page' )
@@ -188,13 +188,13 @@ class Dependency_Minification {
 				<p><?php
 				echo sprintf(
 					'<strong>%1$s</strong>: %2$s',
-					__( 'Dependency Minification', 'dependency-minification' ),
+					__( 'Dependency Minification', 'depmin' ),
 					sprintf(
-						__( 'Pretty permalinks are not enabled in your %1$s, which is required for this plugin to operate. Select something other than Default (e.g. ?p=123)', 'dependency-minification' ),
+						__( 'Pretty permalinks are not enabled in your %1$s, which is required for this plugin to operate. Select something other than Default (e.g. ?p=123)', 'depmin' ),
 						sprintf(
 							'<a href="%1$s">%2$s</a>',
 							admin_url( 'options-permalink.php' ),
-							__( 'Permalinks Settings', 'dependency-minification' )
+							__( 'Permalinks Settings', 'depmin' )
 						)
 					)
 				);
@@ -220,19 +220,19 @@ class Dependency_Minification {
 			<?php if ( 'expire' === $updated_task ) : ?>
 				<p><?php
 				echo esc_html( sprintf(
-					_n( 'Expired %d minified dependency.', 'Expired %d minified dependencies.', $updated_count, 'dependency-minification' ),
+					_n( 'Expired %d minified dependency.', 'Expired %d minified dependencies.', $updated_count, 'depmin' ),
 					$updated_count
 				));
 				?></p>
 			<?php elseif ( 'purge' === $updated_task ) : ?>
 				<p><?php
 				echo esc_html( sprintf(
-					_n( 'Purged %d minified dependency.', 'Purged %d minified dependencies.', $updated_count, 'dependency-minification' ),
+					_n( 'Purged %d minified dependency.', 'Purged %d minified dependencies.', $updated_count, 'depmin' ),
 					$updated_count
 				) );
 				?></p>
 			<?php else: ?>
-				<p><?php esc_html_e( 'Updated.', 'dependency-minification' ) ?></p>
+				<p><?php esc_html_e( 'Updated.', 'depmin' ) ?></p>
 			<?php endif; ?>
 		</div>
 		<?php
@@ -243,10 +243,10 @@ class Dependency_Minification {
 	 */
 	static function admin_ajax_handler() {
 		if ( ! current_user_can( self::$options['admin_page_capability'] ) ) {
-			wp_die( __( 'You are not allowed to do that.', 'dependency-minification' ) );
+			wp_die( __( 'You are not allowed to do that.', 'depmin' ) );
 		}
 		if ( ! wp_verify_nonce( $_REQUEST['_wpnonce'], self::AJAX_ACTION ) ) {
-			wp_die( __( 'Nonce check failed. Try reloading the previous page.', 'dependency-minification' ) );
+			wp_die( __( 'Nonce check failed. Try reloading the previous page.', 'depmin' ) );
 		}
 		$updated_count = 0;
 		if ( ! empty( $_REQUEST['depmin_option_name'] ) && ! empty( $_REQUEST['depmin_task'] ) ) {
@@ -275,7 +275,7 @@ class Dependency_Minification {
 	static function admin_plugin_action_links( $links, $file ) {
 		if ( plugin_basename( __FILE__ ) === $file ) {
 			$admin_page_url  = admin_url( sprintf( '%s?page=%s', self::ADMIN_PARENT_PAGE, self::ADMIN_PAGE_SLUG ) );
-			$admin_page_link = sprintf( '<a href="%s">%s</a>', esc_url( $admin_page_url ), esc_html__( 'Settings', 'dependency-minification' ) );
+			$admin_page_link = sprintf( '<a href="%s">%s</a>', esc_url( $admin_page_url ), esc_html__( 'Settings', 'depmin' ) );
 			array_push( $links, $admin_page_link );
 		}
 		return $links;
@@ -283,13 +283,13 @@ class Dependency_Minification {
 
 	static function admin_page() {
 		if ( ! current_user_can( self::$options['admin_page_capability'] ) ) {
-			wp_die( __( 'You cannot access this page.', 'dependency-minification' ) );
+			wp_die( __( 'You cannot access this page.', 'depmin' ) );
 		}
 		$nonce = wp_create_nonce( self::AJAX_ACTION );
 		?>
 		<div class="wrap">
 			<div class="icon32" id="icon-tools"><br></div>
-			<h2><?php esc_html_e( 'Dependency Minification', 'dependency-minification' ) ?></h2>
+			<h2><?php esc_html_e( 'Dependency Minification', 'depmin' ) ?></h2>
 
 			<?php  ?>
 			<form action="<?php echo esc_url( admin_url( 'admin-ajax.php' ) ) ?>" method="post">
@@ -328,21 +328,21 @@ class Dependency_Minification {
 
 				<?php if ( self::$options['disable_if_wp_debug'] && ( defined( 'WP_DEBUG' ) && WP_DEBUG ) ): ?>
 					<div class="error">
-						<p><?php esc_html_e( 'Dependency Minification is disabled. Any minified dependencies below are cached. To minify new dependencies, disable WP_DEBUG or filter disable_if_wp_debug to be false.', 'dependency-minification' ); ?></p>
+						<p><?php esc_html_e( 'Dependency Minification is disabled. Any minified dependencies below are cached. To minify new dependencies, disable WP_DEBUG or filter disable_if_wp_debug to be false.', 'depmin' ); ?></p>
 					</div>
 				<?php endif; ?>
 
 				<?php if ( empty( $minified_dependencies ) ) : ?>
 					<p>
-						<em><?php esc_html_e( 'There are no minified dependencies yet. Try browsing the site.', 'dependency-minification' ); ?></em>
+						<em><?php esc_html_e( 'There are no minified dependencies yet. Try browsing the site.', 'depmin' ); ?></em>
 					</p>
 				<?php else : ?>
 					<div class="tablenav top">
 						<div class="alignleft actions">
 							<select name="depmin_task">
 								<option value="-1" selected="selected"><?php esc_html_e( 'Bulk Actions' ) ?></option>
-								<option value="expire"><?php esc_html_e( 'Expire', 'dependency-minification' ) ?></option>
-								<option value="purge"><?php esc_html_e( 'Purge', 'dependency-minification' ) ?></option>
+								<option value="expire"><?php esc_html_e( 'Expire', 'depmin' ) ?></option>
+								<option value="purge"><?php esc_html_e( 'Purge', 'depmin' ) ?></option>
 							</select>
 							<input type="submit" name="" id="doaction" class="button action" value="<?php esc_attr_e( 'Apply' ) ?>">
 						</div>
@@ -356,12 +356,12 @@ class Dependency_Minification {
 									<th scope="col" class="manage-column column-cb check-column">
 										<label class="screen-reader-text" for="cb-select-all-1"><?php esc_html_e( 'Select All' ) ?></label><input id="cb-select-all-<?php echo esc_attr( $i + 1 ); ?>" type="checkbox">
 									</th>
-									<th scope="col" class="manage-column column-dependencies"><?php esc_html_e( 'Dependencies', 'dependency-minification' ) ?></th>
-									<th scope="col" class="manage-column column-count"><?php esc_html_e( 'Count', 'dependency-minification' ) ?></th>
-									<th scope="col" class="manage-column column-compression"><?php esc_html_e( 'Compression', 'dependency-minification' ) ?></th>
-									<th scope="col" class="manage-column column-type"><?php esc_html_e( 'Type', 'dependency-minification' ) ?></th>
-									<th scope="col" class="manage-column column-last-modified"><?php esc_html_e( 'Last Modified', 'dependency-minification' ) ?></th>
-									<th scope="col" class="manage-column column-expires"><?php esc_html_e( 'Expires', 'dependency-minification' ) ?></th>
+									<th scope="col" class="manage-column column-dependencies"><?php esc_html_e( 'Dependencies', 'depmin' ) ?></th>
+									<th scope="col" class="manage-column column-count"><?php esc_html_e( 'Count', 'depmin' ) ?></th>
+									<th scope="col" class="manage-column column-compression"><?php esc_html_e( 'Compression', 'depmin' ) ?></th>
+									<th scope="col" class="manage-column column-type"><?php esc_html_e( 'Type', 'depmin' ) ?></th>
+									<th scope="col" class="manage-column column-last-modified"><?php esc_html_e( 'Last Modified', 'depmin' ) ?></th>
+									<th scope="col" class="manage-column column-expires"><?php esc_html_e( 'Expires', 'depmin' ) ?></th>
 								</tr>
 							</<?php echo $tcontainer;  // xss ok ?>>
 						<?php endforeach; ?>
@@ -380,13 +380,13 @@ class Dependency_Minification {
 								?>
 								<tr id="<?php echo esc_attr($option_name) ?>" valign="top">
 									<th scope="row" class="check-column">
-										<label class="screen-reader-text" for="cb-select-<?php echo esc_attr($option_name) ?>"><?php esc_html_e( 'Select minified dependency', 'dependency-minification' ) ?></label>
+										<label class="screen-reader-text" for="cb-select-<?php echo esc_attr($option_name) ?>"><?php esc_html_e( 'Select minified dependency', 'depmin' ) ?></label>
 										<input id="cb-select-<?php echo esc_attr($option_name) ?>" type="checkbox" name="depmin_option_name[]" value="<?php echo esc_attr($option_name) ?>" <?php disabled( $pending ) ?>>
 									</th>
 									<td class="column-dependencies">
 										<strong>
 											<?php for ( $i = 0; $i < count( $deps ); $i += 1 ) : ?>
-												<a href="<?php echo esc_url( $deps[$i]['src'] ) ?>" target="_blank" title="<?php esc_attr_e( 'View unminified source (opens in new window)', 'dependency-minification' ) ?>"><?php echo esc_html( $deps[$i]['handle'] ) ?></a><?php if ( $i + 1 < count( $handles ) ) { esc_html_e( ', ' ); } ?>
+												<a href="<?php echo esc_url( $deps[$i]['src'] ) ?>" target="_blank" title="<?php esc_attr_e( 'View unminified source (opens in new window)', 'depmin' ) ?>"><?php echo esc_html( $deps[$i]['handle'] ) ?></a><?php if ( $i + 1 < count( $handles ) ) { esc_html_e( ', ' ); } ?>
 											<?php endfor; ?>
 										</strong>
 										<?php if ( ! empty( $error ) ) : ?>
@@ -398,8 +398,8 @@ class Dependency_Minification {
 														$_link_params = $link_params;
 														$_link_params['depmin_task'] = 'purge';
 														?>
-														<a class="submitdelete" title="<?php esc_attr_e( 'Delete the cached error to try again.', 'dependency-minification' ) ?>" href="<?php echo esc_url( add_query_arg( $_link_params, admin_url( 'admin-ajax.php' ) ) ) ?>">
-															<?php esc_html_e( 'Try again', 'dependency-minification' ) ?>
+														<a class="submitdelete" title="<?php esc_attr_e( 'Delete the cached error to try again.', 'depmin' ) ?>" href="<?php echo esc_url( add_query_arg( $_link_params, admin_url( 'admin-ajax.php' ) ) ) ?>">
+															<?php esc_html_e( 'Try again', 'depmin' ) ?>
 														</a>
 													</span>
 												</p>
@@ -413,17 +413,17 @@ class Dependency_Minification {
 														$_link_params = $link_params;
 														$_link_params['depmin_task'] = 'expire';
 														?>
-														<a href="<?php echo esc_url( add_query_arg( $_link_params, admin_url( 'admin-ajax.php' ) ) ) ?>" title="<?php esc_attr_e( 'Expire this item to gracefully regenerate', 'dependency-minification' ) ?>"><?php esc_html_e( 'Expire', 'dependency-minification' ) ?></a> |
+														<a href="<?php echo esc_url( add_query_arg( $_link_params, admin_url( 'admin-ajax.php' ) ) ) ?>" title="<?php esc_attr_e( 'Expire this item to gracefully regenerate', 'depmin' ) ?>"><?php esc_html_e( 'Expire', 'depmin' ) ?></a> |
 													</span>
 													<span class="trash">
 														<?php
 														$_link_params = $link_params;
 														$_link_params['depmin_task'] = 'purge';
 														?>
-														<a class="submitdelete" title="<?php esc_attr_e( 'Purge item from cache (delete immediately; NOT recommended)', 'dependency-minification' ) ?>" href="<?php echo esc_url( add_query_arg( $_link_params, admin_url( 'admin-ajax.php' ) ) ) ?>"><?php esc_html_e( 'Purge', 'dependency-minification' ) ?></a> |
+														<a class="submitdelete" title="<?php esc_attr_e( 'Purge item from cache (delete immediately; NOT recommended)', 'depmin' ) ?>" href="<?php echo esc_url( add_query_arg( $_link_params, admin_url( 'admin-ajax.php' ) ) ) ?>"><?php esc_html_e( 'Purge', 'depmin' ) ?></a> |
 													</span>
 													<span class="view">
-														<a href="<?php echo esc_url( $minified_src ) ?>" target="_blank" title="<?php esc_attr_e( 'View minified dependencies (opens in new window)', 'dependency-minification' ) ?>" rel="permalink"><?php esc_html_e( 'View minified', 'dependency-minification' ) ?></a>
+														<a href="<?php echo esc_url( $minified_src ) ?>" target="_blank" title="<?php esc_attr_e( 'View minified dependencies (opens in new window)', 'depmin' ) ?>" rel="permalink"><?php esc_html_e( 'View minified', 'depmin' ) ?></a>
 													</span>
 												<?php else: ?>
 													<span class="trash">
@@ -431,7 +431,7 @@ class Dependency_Minification {
 														$_link_params = $link_params;
 														$_link_params['depmin_task'] = 'purge';
 														?>
-														<a class="submitdelete" title="<?php esc_attr_e( 'Delete the cached error to try again.', 'dependency-minification' ) ?>" href="<?php echo esc_url( add_query_arg( $_link_params, admin_url( 'admin-ajax.php' ) ) ) ?>"><?php esc_html_e( 'Try again', 'dependency-minification' ) ?></a>
+														<a class="submitdelete" title="<?php esc_attr_e( 'Delete the cached error to try again.', 'depmin' ) ?>" href="<?php echo esc_url( add_query_arg( $_link_params, admin_url( 'admin-ajax.php' ) ) ) ?>"><?php esc_html_e( 'Try again', 'depmin' ) ?></a>
 													</span>
 												<?php endif; ?>
 											</div>
@@ -440,13 +440,13 @@ class Dependency_Minification {
 									<td class="count column-count"><?php echo esc_html( count( $handles ) ) ?></td>
 									<td class="count column-compression"><?php
 										if ( empty( $unminified_size ) ) {
-											esc_html_e( 'N/A', 'dependency-minification' );
+											esc_html_e( 'N/A', 'depmin' );
 										} else {
 											$min = strlen( $contents );
 											$max = $unminified_size;
 											$percentage = round( 100 - ( $min / $max ) * 100 );
-											printf( '<meter min=0 max=100 value="%d" title="%s">', $percentage, esc_attr( sprintf( __( '(%1$d / %2$d)', 'dependency-minification' ), $min, $max ) ) );
-											print esc_html( sprintf( __( '%1$d%%', 'dependency-minification' ), $percentage ) );
+											printf( '<meter min=0 max=100 value="%d" title="%s">', $percentage, esc_attr( sprintf( __( '(%1$d / %2$d)', 'depmin' ), $min, $max ) ) );
+											print esc_html( sprintf( __( '%1$d%%', 'depmin' ), $percentage ) );
 											print '</meter>';
 										}
 
@@ -461,7 +461,7 @@ class Dependency_Minification {
 									<?php foreach ( $date_cols as $col => $time ) : ?>
 										<td class="<?php echo esc_attr( $col ) ?> column-<?php echo esc_attr( $col ) ?>">
 											<?php if ( $pending ) : ?>
-												<em><?php esc_html_e( '(Pending)', 'dependency-minification' ) ?></em>
+												<em><?php esc_html_e( '(Pending)', 'depmin' ) ?></em>
 											<?php else: ?>
 												<time title="<?php echo esc_attr( gmdate( 'c', $time ) ) ?>" datetime="<?php echo esc_attr( gmdate( 'c', $time ) ) ?>">
 													<?php if ( $time < time() ) : ?>

--- a/dependency-minification.php
+++ b/dependency-minification.php
@@ -99,7 +99,7 @@ class Dependency_Minification {
 		}
 		$new_rules[$regex] = $redirect;
 
-		return array_merge( $rules, $new_rules );
+		return array_merge( $new_rules, $rules );
 	}
 
 	static function remove_rewrite_rule() {

--- a/dependency-minification.php
+++ b/dependency-minification.php
@@ -505,7 +505,7 @@ class Dependency_Minification {
 	static function get_dependency_minified_url( array $deps, $type ) {
 		$src_hash = self::hash_array( wp_list_pluck( $deps, 'src' ) );
 		$ver_hash = self::hash_array( wp_list_pluck( $deps, 'ver' ) );
-		$src = trailingslashit( home_url( self::$options['endpoint'] ) );
+		$src = trailingslashit( get_option( 'home' ) . DIRECTORY_SEPARATOR . self::$options['endpoint'] );
 		$src .= join( '.', array(
 			join( ',', wp_list_pluck( $deps, 'handle' ) ),
 			$src_hash,


### PR DESCRIPTION
This solves the issue by adding the minify rewrite rule to the end of the rewrite_rules_array insuring in theory that the rule can not be broken by an external rewrite filter.

@westonruter please reivew
