### PR TITLE
Protocol-relative links for minify endpoints, fixes #50

### DIFF
--- a/dependency-minification.php
+++ b/dependency-minification.php
@@ -512,7 +512,7 @@ class Dependency_Minification {
 			$ver_hash,
 			$type === 'scripts' ? 'js' : 'css',
 		) );
-		return $src;
+		return preg_replace( '#^https?:(?=//)#', '', $src );
 	}
 
 	/**


### PR DESCRIPTION
we are currently using get_option( "home" ) to build the $src address.
wordpress does not support protocol relative home address still as of 3.9,
see https://core.trac.wordpress.org/ticket/21153
