### PR TITLE
Added max_age header

### DIFF
--- a/dependency-minification.php
+++ b/dependency-minification.php
@@ -1013,6 +1013,7 @@ class Dependency_Minification {
 			$max_age = apply_filters( 'dependency_minification_cache_control_max_age', (int) self::$options['cache_control_max_age_cache'], $srcs );
 			$cached['contents'] = $contents;
 			$cached['expires'] = time() + $max_age;
+			$cached['max_age'] = $max_age;
 			$cached['error'] = null;
 		}
 		catch (Exception $e) {
@@ -1070,6 +1071,7 @@ class Dependency_Minification {
 
 			// Send the response headers for caching
 			header( 'Expires: ' . str_replace( '+0000', 'GMT', gmdate( 'r', $cached['expires'] ) ) );
+			header( 'Cache-Control: ' . 'public, max-age=' . $cached['max_age'] );
 			if ( ! empty( $cached['last_modified'] ) ) {
 				header( 'Last-Modified: ' . str_replace( '+0000', 'GMT', gmdate( 'r', $cached['last_modified'] ) ) );
 			}


### PR DESCRIPTION
@westonruter 

When using this on a project, just with the Expire header, Google Page Speed was complaining of not leveraging browser caching.

"Leverage browser caching
You have enabled browser caching. Learn more about browser caching recommendations."

With this patch, the browser caching is used properly, and makes the caching test pass.

I've guided myself by this when making these amendments:
https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching#cache-control
